### PR TITLE
Use full key ID for nginx repo

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -36,7 +36,7 @@ class nginx::package::debian(
         apt::source { 'nginx':
           location   => "http://nginx.org/packages/${distro}",
           repos      => 'nginx',
-          key        => '7BD9BF62',
+          key        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
           key_source => 'http://nginx.org/keys/nginx_signing.key',
         }
       }
@@ -44,7 +44,7 @@ class nginx::package::debian(
         apt::source { 'nginx':
           location   => "http://nginx.org/packages/mainline/${distro}",
           repos      => 'nginx',
-          key        => '7BD9BF62',
+          key        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
           key_source => 'http://nginx.org/keys/nginx_signing.key',
         }
       }


### PR DESCRIPTION
To get rid of messages like:
`The id should be a full fingerprint (40 characters), see README`
